### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are currently some features missing from the generator. These will be avai
 ## Installation
 ```bash
 npm install -g yo
-npm install -g generator-react-webpack-alt
+npm install generator-react-webpack-alt
 ```
 
 ## Setting up projects


### PR DESCRIPTION
It's not working for me when installed globally (-g), please look at https://github.com/newtriks/generator-react-webpack README.md.

```
yo react-webpack-alt
Error react-webpack-alt 

You don't seem to have a generator with the name react-webpack-alt installed.
You can see available generators with npm search yeoman-generator and then install them with npm install [name].
To see the 2 registered generators run yo with the `--help` option.
```
